### PR TITLE
Allow changing shade slot cap + prefer maintaining data

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,6 +243,7 @@
 						<tr v-for="(colorSlot, colorSlotIndex) in colorProfilesMainColors"
 							class="colorSlot"
 						>
+							<td class="color centertxt"><div v-if="colorSlotIndex > 31" title="this slot will not show up in-game.">[!]</div></td>
 							<td class="color centertxt">
 								<div v-if="colorSlotIndex > 1" class="fakebutton" @click="moveShadeUp(colorSlotIndex)" name="move alt palette up">▲</div>
 							</td>

--- a/index.html
+++ b/index.html
@@ -196,6 +196,7 @@
 					</ul>
 					<table id="colors">
 						<tr class="shadeRow" v-for="(row, iRow) in rows">
+							<td class="color centertxt"><div v-if="iRow > 7" title="this slot will not affect the sprite.">[!]</div></td>
 							<td class="color centertxt"><div v-if="iRow > 0" class="fakebutton" @click="moveRowUp(iRow)" name="move slot up">▲</div></td>
 							<td class="color centertxt"><div v-if="iRow < rows.length - 1" class="fakebutton" @click="moveRowDown(iRow)" name="move slot down">▼</div></td>
 							<td class="rowDeletButton" @click="deleteRow(iRow)" title="delete row"><div>🗑️</div></td>
@@ -220,9 +221,9 @@
 						</td>
 							<td class="color centertxt"><div class="fakebutton" @click="addSlot(row)" title="add slot">+</div></td>
 						</tr>
-						<tr v-if="rows.length < 8">
+						<tr v-if="rows.length < MAX_SHADE_ROWS">
 							<td colspan=100% style="padding-top: 2px;">
-								<button style="width: 100%;" @click="addRow()" title="add row">add row ({{rows.length}} / 8)</button>
+								<button style="width: 100%;" @click="addRow()" title="add row">add row ({{rows.length}} / {{MAX_SHADE_ROWS}})</button>
 							</td>
 						</tr>
 					</table>
@@ -328,6 +329,12 @@
 							<label>
 								<input type="number" name="max number of alts" min="32" step="1" style="width: 40px" v-model:value="MAX_ALT_PALETTES"></input>
 								Max number of alts <span class="sneakyText">(note that the game only allows a maximum of 32! This is for convenience only.)</span>
+							</label>
+						</li>
+						<li>
+							<label>
+								<input type="number" name="max number of shades" min="8" step="1" style="width: 40px" v-model:value="MAX_SHADE_ROWS"></input>
+								Max number of shades <span class="sneakyText">(note that the color shader only uses 8 shade slots! anything past that will not be recolored.)</span>
 							</label>
 						</li>
 						<li>

--- a/index.js
+++ b/index.js
@@ -883,53 +883,6 @@ const vm = new Vue({
 									//console.log("px", i, "fitting rangeDef", hsv, mainColorForShade.hsv, defaultToCurrentDeltaHSV, shiftedRgb)
 								}
 							})
-							/*
-							// I tested this (albeit hastily) and discerned that the performance difference was negligable and
-							// this might even be worse (similar avg, more fluctuation in min/max). leaving it here for
-							// prosperity and/or better testing.
-
-							let shadeIndex = 0;
-							for (const rangeDef of this.ranges) {
-								if (shadeIndex >= 8)
-									break; //prevent coloring anything past shade slot 7, as the game would not do.
-								const hsv = rgbToHsv(r, g, b);
-
-								//those ranges are precalculated in generateGmlCode so that we don't have to math them here
-								if(isWrappingValueWithinRange(hsv.h, 0, 360, rangeDef.hL, rangeDef.hH)
-								&& hsv.s >= rangeDef.sL && hsv.s <= rangeDef.sH
-								&& hsv.v >= rangeDef.vL && hsv.v <= rangeDef.vH
-								) {
-									const mainColorForShade = this.colorProfilesMainColors[this.selectedColorProfile].shades[shadeIndex];
-									matched = true;
-									const defaultColorForShade = this.colorProfilesMainColors[0].shades[shadeIndex];
-
-
-									const accurateHSV = rgbToHsv_noRounding(r, g, b);
-
-									const defaultToCurrentDeltaHSV = getHSVDelta(defaultColorForShade.accurateHSV, accurateHSV);
-									const shiftedHSV = applyDeltaToHSV(mainColorForShade.accurateHSV, defaultToCurrentDeltaHSV);
-
-									const shiftedRgb = hsvToRgb_noRounding(shiftedHSV.h, shiftedHSV.s, shiftedHSV.v);
-									const mainToShiftedDeltaRGB = getRGBDelta(mainColorForShade.rgb, shiftedRgb);
-									const shiftedRgb2 = applyDeltaToRGB({...shiftedRgb}, {
-										r: mainToShiftedDeltaRGB.r * (this.shadingValue - 1),
-										g: mainToShiftedDeltaRGB.g * (this.shadingValue - 1),
-										b: mainToShiftedDeltaRGB.b * (this.shadingValue - 1)
-									});
-
-
-									imageDataArray[i] = shiftedRgb2.r;
-									imageDataArray[i+1] = shiftedRgb2.g;
-									imageDataArray[i+2] = shiftedRgb2.b;
-
-									cachedColorTransforms.set(`${r},${g},${b}`, shiftedRgb2);
-
-									//console.log("px", i, "fitting rangeDef", hsv, mainColorForShade.hsv, defaultToCurrentDeltaHSV, shiftedRgb)
-								}
-								
-								shadeIndex++;
-							}
-							*/
 
 							if (!matched) {
 								//reaching here means the color wasn't fitting in any range

--- a/index.js
+++ b/index.js
@@ -843,7 +843,9 @@ const vm = new Vue({
 									"vL", hsv.v >= rangeDef.vL,
 									"vH", hsv.v <= rangeDef.vH
 								)*/
-
+								if (shadeIndex >= 8)
+									return; //prevent coloring anything past shade slot 7, as the game would not do. 
+											//would've used break instead but forEach doesn't support that!
 								const hsv = rgbToHsv(r, g, b);
 
 								//those ranges are precalculated in generateGmlCode so that we don't have to math them here
@@ -879,6 +881,54 @@ const vm = new Vue({
 									//console.log("px", i, "fitting rangeDef", hsv, mainColorForShade.hsv, defaultToCurrentDeltaHSV, shiftedRgb)
 								}
 							})
+							/*
+							// I tested this (albeit hastily) and discerned that the performance difference was negligable and
+							// this might even be worse (similar avg, more fluctuation in min/max). leaving it here for
+							// prosperity and/or better testing.
+
+							let shadeIndex = 0;
+							for (const rangeDef of this.ranges) {
+								if (shadeIndex >= 8)
+									break; //prevent coloring anything past shade slot 7, as the game would not do.
+								const hsv = rgbToHsv(r, g, b);
+
+								//those ranges are precalculated in generateGmlCode so that we don't have to math them here
+								if(isWrappingValueWithinRange(hsv.h, 0, 360, rangeDef.hL, rangeDef.hH)
+								&& hsv.s >= rangeDef.sL && hsv.s <= rangeDef.sH
+								&& hsv.v >= rangeDef.vL && hsv.v <= rangeDef.vH
+								) {
+									const mainColorForShade = this.colorProfilesMainColors[this.selectedColorProfile].shades[shadeIndex];
+									matched = true;
+									const defaultColorForShade = this.colorProfilesMainColors[0].shades[shadeIndex];
+
+
+									const accurateHSV = rgbToHsv_noRounding(r, g, b);
+
+									const defaultToCurrentDeltaHSV = getHSVDelta(defaultColorForShade.accurateHSV, accurateHSV);
+									const shiftedHSV = applyDeltaToHSV(mainColorForShade.accurateHSV, defaultToCurrentDeltaHSV);
+
+									const shiftedRgb = hsvToRgb_noRounding(shiftedHSV.h, shiftedHSV.s, shiftedHSV.v);
+									const mainToShiftedDeltaRGB = getRGBDelta(mainColorForShade.rgb, shiftedRgb);
+									const shiftedRgb2 = applyDeltaToRGB({...shiftedRgb}, {
+										r: mainToShiftedDeltaRGB.r * (this.shadingValue - 1),
+										g: mainToShiftedDeltaRGB.g * (this.shadingValue - 1),
+										b: mainToShiftedDeltaRGB.b * (this.shadingValue - 1)
+									});
+
+
+									imageDataArray[i] = shiftedRgb2.r;
+									imageDataArray[i+1] = shiftedRgb2.g;
+									imageDataArray[i+2] = shiftedRgb2.b;
+
+									cachedColorTransforms.set(`${r},${g},${b}`, shiftedRgb2);
+
+									//console.log("px", i, "fitting rangeDef", hsv, mainColorForShade.hsv, defaultToCurrentDeltaHSV, shiftedRgb)
+								}
+								
+								shadeIndex++;
+							}
+							*/
+
 							if (!matched) {
 								//reaching here means the color wasn't fitting in any range
 								//console.log("unmatched color", r, g, b);

--- a/index.js
+++ b/index.js
@@ -408,8 +408,8 @@ const vm = new Vue({
 					this.colorProfilesMainColors[colorProfileSlot] = {shades: []};
 
 				console.log("adding shade", colorProfileSlot, shadeSlot, rgb)
-
 				this.colorProfilesMainColors[colorProfileSlot].shades[shadeSlot] = { rgb };
+				
 				this.calcShadesHSV(this.colorProfilesMainColors[colorProfileSlot].shades[shadeSlot]);
 			}
 
@@ -422,6 +422,8 @@ const vm = new Vue({
 					this.setMainColor(newSlot, newRow);
 				})
 			}
+
+			
 
 			const regComment = /^\/\/[ \t]*(.*)/g
 			var i = 1;
@@ -448,8 +450,11 @@ const vm = new Vue({
 			})
 
 			//only keep 16 color profiles
+			//if (this.colorProfilesMainColors.length > this.MAX_ALT_PALETTES)
+			//	this.colorProfilesMainColors.splice(this.MAX_ALT_PALETTES, this.colorProfilesMainColors.length - 1)
+
 			if (this.colorProfilesMainColors.length > this.MAX_ALT_PALETTES)
-				this.colorProfilesMainColors.splice(this.MAX_ALT_PALETTES, this.colorProfilesMainColors.length - 1)
+				this.MAX_ALT_PALETTES = this.colorProfilesMainColors.length; //prefer maintaining user data.
 
 			this.colorProfilesMainColors.forEach(this.fillShadeSlotsUpToAmountOfRows)
 
@@ -470,7 +475,10 @@ const vm = new Vue({
 			this.rows = [];
 
 			try {
-				this.rows = json.splice(0, this.MAX_SHADE_ROWS);
+				//this.rows = json.splice(0, this.MAX_SHADE_ROWS);
+
+				this.rows = json;
+				this.MAX_SHADE_ROWS = Math.max(8,this.rows.length); // prefer maintaining user data.
 
 				console.log("checking", this.rows.length, "rows")
 				for (let i = 0; i < this.rows.length; i++) {

--- a/index.js
+++ b/index.js
@@ -449,12 +449,8 @@ const vm = new Vue({
 				}
 			})
 
-			//only keep 16 color profiles
-			//if (this.colorProfilesMainColors.length > this.MAX_ALT_PALETTES)
-			//	this.colorProfilesMainColors.splice(this.MAX_ALT_PALETTES, this.colorProfilesMainColors.length - 1)
-
 			if (this.colorProfilesMainColors.length > this.MAX_ALT_PALETTES)
-				this.MAX_ALT_PALETTES = this.colorProfilesMainColors.length; //prefer maintaining user data.
+				this.MAX_ALT_PALETTES = this.colorProfilesMainColors.length;
 
 			this.colorProfilesMainColors.forEach(this.fillShadeSlotsUpToAmountOfRows)
 
@@ -475,10 +471,8 @@ const vm = new Vue({
 			this.rows = [];
 
 			try {
-				//this.rows = json.splice(0, this.MAX_SHADE_ROWS);
-
 				this.rows = json;
-				this.MAX_SHADE_ROWS = Math.max(8,this.rows.length); // prefer maintaining user data.
+				this.MAX_SHADE_ROWS = Math.max(8,this.rows.length);
 
 				console.log("checking", this.rows.length, "rows")
 				for (let i = 0; i < this.rows.length; i++) {


### PR DESCRIPTION
Shade slots above the normal cap (8) are still readable/writable in rivals, but aren't used by the color shader. You can however use them to store miscellaneous data. Reading them is done using the functions `get_profile_color_slot_r/g/b`
For example, I use it to store the two endpoints of a color transition in an upcoming character.

I also modified the parsing functions to increase the maximum slot values rather than destroy the additional colors and shades, as it makes for less steps when importing a colors.gml file with more than the normal amount of data, because that additional data is still usable in-game.

additionally, a warning was added to color and shade slots above the game's technical maximum.