### PR TITLE
add per-slot shading values and toggle to ignore shade limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
 							zoom:
 							<input type="number" name="zoom" min="1" style="width: 40px" v-model:value="zoomFactor" @input="zoomFactor=Math.max(1, parseInt(zoomFactor))"></input>
 						</label>
-						<label>
+						<label v-if="!PER_SLOT_SHADING">
 							shading value:
 							<input type="number" name="shading value" step="0.1" style="width: 40px" v-model:value="inputShadingValue"></input>
 							<!--<button @click="inputShadingValue=0">0</button>

--- a/index.html
+++ b/index.html
@@ -364,6 +364,12 @@
 							</label>
 						</li>
 						<li>
+							<label>
+								<input type="checkbox" name="ignore shade limit" v-model:value="IGNORE_SHADE_LIMIT"></input>
+								{{(IGNORE_SHADE_LIMIT ? 'I' : 'Not i') + 'gnoring the in-game shade slot limit.'}}  <span class="sneakyText">(the color shader only uses 8 shade slots! only turn this on if you know what you're doing.)</span>
+							</label>
+						</li>
+						<li>
 							<input type="checkbox" id="autoMoveShades" v-model="autoMoveShades"></input>
 							<label for="autoMoveShades">{{ (autoMoveShades ? 'A' : 'Not a') + 'utomatically moving shades when palette rows are moved' }}</label>
 						</li>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,10 @@
 							<button @click="hide(); $emit('delete-color')">remove</button>
 							<button style="float:right;" @click="$emit('set-main')">set main</button>
 						</div>
+						<div v-if="showshadecontrol && c_per_slot_shading" style="margin-bottom: 1rem;">
+							<label style="color: black; margin: 0px; margin-top: 5px; scale: 0.5">shading value:</label>
+							<input type="number" name="shadingvalue" step="0.1" style="width: 40px" v-bind:value="shd_val" v-on:input="shd_val = Number($event.target.value);" v-on:change="askRerender" v-bind:disabled="readonly"/>
+						</div>
 						<div class="control" v-bind:style="gradientH">
 							<input type="range" min="0" max="360" v-bind:value="h" v-on:input="h = Number($event.target.value); updateFromHsv();" v-on:change="askRerender" v-bind:disabled="readonly"/>
 						</div>
@@ -269,7 +273,10 @@
 									v-bind:_r.sync = "shade.rgb.r"
 									v-bind:_g.sync = "shade.rgb.g"
 									v-bind:_b.sync = "shade.rgb.b"
+									v-bind:_shd_val.sync = "shade.shd_val"
+									v-bind:c_per_slot_shading.sync = "PER_SLOT_SHADING"
 
+									showshadecontrol = "true"
 									@color-update = "calcShadesHSV(shade); $forceUpdate(); generateGmlCode();"
 									@rerender = "renderPreview"
 								>
@@ -277,6 +284,10 @@
 							</td>
 							<td v-if="colorSlotIndex > 5" class="rowDeletButton" @click="deleteColorSlotRow(colorSlotIndex)" title="delete row">
 								<div>🗑️</div>
+							</td>
+							<td v-else></td>
+							<td v-if="colorSlotIndex > 0" class="rowDeletButton" @click="changeSlotRowIndex(colorSlotIndex)">
+								<div>↕️</div>
 							</td>
 						</tr>
 						<tr v-if="colorProfilesMainColors.length < MAX_ALT_PALETTES">
@@ -325,7 +336,15 @@
 					</ul>
 
 					<ul class="no-style-list flush-list">
-
+						<li>
+							<label>
+								R: <input type="number" name="R" min="0" max="255" step="1" style="width: 40px" v-model:value="customOutline.r"></input>
+								G: <input type="number" name="G" min="0" max="255" step="1" style="width: 40px" v-model:value="customOutline.g"></input>
+								B: <input type="number" name="B" min="0" max="255" step="1" style="width: 40px" v-model:value="customOutline.b"></input>
+								
+								Custom outline color <span class="sneakyText">(The game replaces any color under rgb(26, 26, 26) with this color. This is only a preview - it isn't written to the resulting colors.gml code. See <a title="Player Variables - Rivals of Aether" href="https://rivalsofaether.com/player-variables/">Player Variables</a>.)</span>
+							</label>
+						</li>
 						<li>
 							<label>
 								<input type="number" name="max number of alts" min="32" step="1" style="width: 40px" v-model:value="MAX_ALT_PALETTES"></input>
@@ -336,6 +355,12 @@
 							<label>
 								<input type="number" name="max number of shades" min="8" step="1" style="width: 40px" v-model:value="MAX_SHADE_ROWS"></input>
 								Max number of shades <span class="sneakyText">(note that the color shader only uses 8 shade slots! anything past that will not be recolored.)</span>
+							</label>
+						</li>
+						<li>
+							<label>
+								<input type="checkbox" name="per slot shading" v-model:value="PER_SLOT_SHADING"></input>
+								Per-slot shading values <span class="sneakyText">(The color tool does not generate the code to apply this shading value.)</span>
 							</label>
 						</li>
 						<li>

--- a/index.js
+++ b/index.js
@@ -294,6 +294,7 @@ const vm = new Vue({
 		MAX_ALT_PALETTES: 32,
 		MAX_SHADE_ROWS: 8,
 		PER_SLOT_SHADING: false,
+		IGNORE_SHADE_LIMIT: false,
 		userHasEditedThings: false,
 		customOutline: { r: 0, g: 0, b: 0 },
 	},
@@ -353,7 +354,8 @@ const vm = new Vue({
 			handler: 'updateInput'
 		},
 		shadingValue: 'renderPreview',
-		zoomFactor: 'renderPreview'
+		zoomFactor: 'renderPreview',
+		IGNORE_SHADE_LIMIT: 'renderPreview'
 	},
 	methods: {
 		copyImage: async function() {
@@ -917,7 +919,7 @@ const vm = new Vue({
 									"vL", hsv.v >= rangeDef.vL,
 									"vH", hsv.v <= rangeDef.vH
 								)*/
-								if (shadeIndex >= 8)
+								if (shadeIndex >= 8 && !this.IGNORE_SHADE_LIMIT)
 									return; //prevent coloring anything past shade slot 7, as the game would not do. 
 											//would've used break instead but forEach doesn't support that!
 								const hsv = rgbToHsv(r, g, b);

--- a/index.js
+++ b/index.js
@@ -933,7 +933,7 @@ const vm = new Vue({
 									matched = true;
 									const defaultColorForShade = this.colorProfilesMainColors[0].shades[shadeIndex];
 
-									const shd_val = mainColorForShade.shd_val;
+									const shd_val = this.PER_SLOT_SHADING ? mainColorForShade.shd_val : this.shadingValue;
 									
 									const accurateHSV = rgbToHsv_noRounding(r, g, b);
 

--- a/index.js
+++ b/index.js
@@ -468,6 +468,9 @@ const vm = new Vue({
 								var matches = regex.exec(line)
 								this.colorProfilesMainColors[i-1].shades.forEach((shade, shade_index) => {
 									shade.shd_val = Number(matches[shade_index+1]);
+									if (shade.shd_val !== 1) {
+										this.PER_SLOT_SHADING = true
+									}
 								});
 								return;
 							}
@@ -758,10 +761,13 @@ const vm = new Vue({
 					if (this.rows[shadeIndex])
 						str += ` //${this.rows[shadeIndex].name}`;
 				})
-				str += "\n//shading data: ["
-				colorSlot.shades.forEach((shade, shadeIndex) => {
-					str += shade.shd_val + (shadeIndex < colorSlot.shades.length-1 ? ", ":"]")
-				})
+				
+				if (this.PER_SLOT_SHADING) {
+					str += "\n//shading data: ["
+					colorSlot.shades.forEach((shade, shadeIndex) => {
+						str += shade.shd_val + (shadeIndex < colorSlot.shades.length-1 ? ", ":"]")
+					})
+				}
 			}
 			
 

--- a/index.js
+++ b/index.js
@@ -917,8 +917,8 @@ const vm = new Vue({
 									"vL", hsv.v >= rangeDef.vL,
 									"vH", hsv.v <= rangeDef.vH
 								)*/
-								//if (shadeIndex >= 8)
-									//return; //prevent coloring anything past shade slot 7, as the game would not do. 
+								if (shadeIndex >= 8)
+									return; //prevent coloring anything past shade slot 7, as the game would not do. 
 											//would've used break instead but forEach doesn't support that!
 								const hsv = rgbToHsv(r, g, b);
 

--- a/index.js
+++ b/index.js
@@ -355,7 +355,8 @@ const vm = new Vue({
 		},
 		shadingValue: 'renderPreview',
 		zoomFactor: 'renderPreview',
-		IGNORE_SHADE_LIMIT: 'renderPreview'
+		IGNORE_SHADE_LIMIT: 'renderPreview',
+		PER_SLOT_SHADING: 'updateInput'
 	},
 	methods: {
 		copyImage: async function() {


### PR DESCRIPTION
added two toggles.

the first toggle is for enabling/disabling per-slot shading values, which adds a number input to the color picker on the alt palette color picker. (should this be a toggle actually?)
the second toggle bypasses the hardcoded 8 shade slot recoloring limit, as it IS possible to bypass that limit in-game, and is uncommonly done.

i'm not 100% certain that i accomplished these goals as well as i could? notably i'm not sure about the slight format change, which makes each palette look like the following
```gml
// example alt
set_color_profile_slot( 1, 0, 0, 0, 0 ); // example_shade
//shading data: [1]
```
it is convenient to have the shading data included in the colors.gml output like this (as opposed to in the data dictionary), though it isn't pretty

notably, copy and paste operations on colors do not include the shading value, which is also a minor gripe.